### PR TITLE
Update hello_arc.yaml - new image URL

### DIFF
--- a/hello-arc/yaml/hello_arc.yaml
+++ b/hello-arc/yaml/hello_arc.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
       - name: hello-arc
-        image: jumpstartprod.azurecr.io/hello-arc:latest
+        image: mcr.microsoft.com/jumpstart/arcbox/hello_arc:20240926
         ports:
         - containerPort: 8080
         env:


### PR DESCRIPTION
This pull request includes a small but significant change to the `hello-arc` container image reference in the `hello_arc.yaml` file. The change updates the image source to a new repository and tag.

* [`hello-arc/yaml/hello_arc.yaml`](diffhunk://#diff-891422df1742ab7f244d751f319eac4bc306ab30e496bd15a829b752fdc3d29eL31-R31): Updated the container image from `jumpstartprod.azurecr.io/hello-arc:latest` to `mcr.microsoft.com/jumpstart/arcbox/hello_arc:20240926`.